### PR TITLE
fix: call callback before returning early

### DIFF
--- a/lua/blink-cmp-conventional-commits/init.lua
+++ b/lua/blink-cmp-conventional-commits/init.lua
@@ -62,11 +62,13 @@ end
 function conventional_commits:get_completions(context, callback)
     local row, col = unpack(context.cursor)
     if row ~= 1 or col > 8 then
+        callback()
         return -- only complete at beginning of the first line
     end
 
     local words = vim.split(context.line, ' ')
     if #words > 1 then
+        callback()
         return -- only complete the first word
     end
 


### PR DESCRIPTION
If the callback is not called then blink.cmp will hang and just assume that it is taking a long time fetching the completions.

This will mean that any other completion engine is blocked by the timeout for blink-cmp-conventional-commits.