### PR TITLE
feat: add scope completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ example using [Lazy](https://github.com/folke/lazy.nvim) plugin manager
 }
 ```
 
+## Scope Completion
+
+The plugin automatically discovers scopes used in the repository by
+scanning recent non-merge commits. When you type `feat(` or any other
+type followed by an opening parenthesis, completions for previously
+used scopes will appear.
+
+Scopes are discovered at plugin load time from `git log`. The number
+of commits to scan can be configured via `git_log_count` (default: 200):
+
+```lua
+opts = {
+    git_log_count = 500, -- scan last 500 non-merge commits for scopes
+}
+```
+
+To disable scope completion entirely:
+
+```lua
+opts = {
+    scopes = false,
+}
+```
+
 ## Configuration
 
 The plugin provides several configuration options to customize the conventional commit types:

--- a/lua/blink-cmp-conventional-commits/init.lua
+++ b/lua/blink-cmp-conventional-commits/init.lua
@@ -10,10 +10,51 @@
 
 ---@class blink-cmp-conventional-commits.Options
 ---@field completion? blink-cmp-conventional-commits.CompletionOptions
+---@field git_log_count? integer Number of non-merge commits to scan for scopes (default: 200)
+---@field scopes? false Disable automatic scope discovery
 
 ---@class ConventionalCommitsSource : blink.cmp.Source, blink-cmp-conventional-commits.Options
 ---@field completion_items blink.cmp.CompletionItem[]
+---@field scope_items blink.cmp.CompletionItem[]
 local conventional_commits = {}
+
+---@param scope string
+---@return blink.cmp.CompletionItem
+local function make_scope_item(scope)
+    return {
+        label = scope,
+        insertText = scope,
+        kind = require('blink.cmp.types').CompletionItemKind.Value,
+    }
+end
+
+---@param count integer
+---@param callback fun(scopes: string[])
+local function discover_scopes(count, callback)
+    vim.system(
+        { 'git', 'log', '--no-merges', '--oneline', '-' .. count },
+        { text = true },
+        vim.schedule_wrap(function(result)
+            if result.code ~= 0 then
+                callback {}
+                return
+            end
+            local seen = {}
+            local scopes = {}
+            for line in result.stdout:gmatch '[^\n]+' do
+                local scope = line:match '^%x+ %w+%((.-)%)'
+                if scope then
+                    scope = scope:match '^%s*(.-)%s*$'
+                    if scope ~= '' and not seen[scope] then
+                        seen[scope] = true
+                        table.insert(scopes, scope)
+                    end
+                end
+            end
+            callback(scopes)
+        end)
+    )
+end
 
 ---@param type string
 ---@param doc string
@@ -81,6 +122,19 @@ function conventional_commits.new(opts)
     end)
 
     opts.completion_items = completion_items
+
+    opts.scope_items = {}
+    if opts.scopes ~= false then
+        discover_scopes(opts.git_log_count or 200, function(scopes)
+            local items = {}
+
+            for _, scope in ipairs(scopes) do
+                table.insert(items, make_scope_item(scope))
+            end
+            opts.scope_items = items
+        end)
+    end
+
     return setmetatable(opts, { __index = conventional_commits })
 end
 
@@ -120,6 +174,15 @@ function conventional_commits:get_completions(context, callback)
             -- add optional footer below
             callback {
                 items = { get_breaking_completion_item() },
+            }
+        elseif
+            #self.scope_items > 0 and line_before_cursor:match '^%w+%([^)]*$'
+        then
+            -- complete scopes inside type(...)
+            callback {
+                is_incomplete_forward = false,
+                is_incomplete_backward = false,
+                items = vim.deepcopy(self.scope_items),
             }
         elseif not line_before_cursor:find '[():]' then
             -- only complete conventional commits for first word of first line before ':' and optional scope


### PR DESCRIPTION
Parses the last 200 commits to extract previously used scopes, offering them as completions when the cursor is inside type(...).

Close https://github.com/disrupted/blink-cmp-conventional-commits/issues/3